### PR TITLE
ci: add separate main to develop backmerge workflow for non-hotfix merges

### DIFF
--- a/.github/workflows/backmerge-main-sync.yml
+++ b/.github/workflows/backmerge-main-sync.yml
@@ -13,7 +13,8 @@ jobs:
     if: >
       github.event.pull_request.merged == true &&
       github.event.pull_request.base.ref == 'main' &&
-      github.event.pull_request.head.ref != 'develop' &&
+      !(github.event.pull_request.head.ref == 'develop' &&
+        github.event.pull_request.head.repo.full_name == github.repository) &&
       !startsWith(github.event.pull_request.head.ref, 'hotfix/')
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
# Hotfix Pull Request\n\n## Summary\n- keep existing hotfix backmerge workflow unchanged\n- add separate workflow file .github/workflows/backmerge-main-sync.yml for non-hotfix merges into main\n- prevent duplicate sync PR creation when one already exists\n- no-op safely when branches are already in sync\n\n## Rollback Plan\n- Revert commit 3fe1b50 from develop/main if workflow behavior is undesired.\n\nCloses #33