### PR TITLE
fix(release): auto-insert missing docs version markers during packaging

### DIFF
--- a/scripts/build-public-artifact.sh
+++ b/scripts/build-public-artifact.sh
@@ -4,5 +4,6 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/python-resolver.sh"
 
-python3 "$SCRIPT_DIR/public_manifest_tool.py" build "$@"
+tm_python_run "$SCRIPT_DIR/public_manifest_tool.py" build "$@"

--- a/scripts/lib/python-resolver.sh
+++ b/scripts/lib/python-resolver.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Resolve a Python 3-capable interpreter portably across Linux/macOS/WSL/Windows Git Bash.
+# Preference order: python3 -> python -> py -3
+
+tm_python_run() {
+  if command -v python3 >/dev/null 2>&1; then
+    python3 "$@"
+    return
+  fi
+  if command -v python >/dev/null 2>&1; then
+    python "$@"
+    return
+  fi
+  if command -v py >/dev/null 2>&1; then
+    py -3 "$@"
+    return
+  fi
+
+  echo "No Python interpreter found. Install Python 3 and ensure one of 'python3', 'python', or 'py' is on PATH." >&2
+  return 127
+}
+
+tm_python_label() {
+  if command -v python3 >/dev/null 2>&1; then
+    echo "python3"
+    return
+  fi
+  if command -v python >/dev/null 2>&1; then
+    echo "python"
+    return
+  fi
+  if command -v py >/dev/null 2>&1; then
+    echo "py -3"
+    return
+  fi
+  echo "<missing-python>"
+}
+

--- a/scripts/prepare-public-release.sh
+++ b/scripts/prepare-public-release.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
+source "$ROOT_DIR/scripts/lib/python-resolver.sh"
 
 input_version="${1:-}"
 release_branch="${RELEASE_BRANCH:-main}"
@@ -41,7 +42,7 @@ if [[ "$allow_non_release_branch" != "1" && "$enforce_release_ref_sync" == "1" ]
 fi
 
 compute_release_version() {
-  python3 - "$input_version" <<'PY'
+  tm_python_run - "$input_version" <<'PY'
 import json
 import re
 import subprocess
@@ -194,7 +195,7 @@ delegation_used="none"
 docs_management_used="none"
 
 # Build sanitized staging tree from manifest.
-python3 scripts/public_manifest_tool.py build \
+tm_python_run scripts/public_manifest_tool.py build \
   --root "$ROOT_DIR" \
   --manifest "$ROOT_DIR/release/public-manifest.yaml" \
   --output "$staging_dir"
@@ -283,7 +284,7 @@ cat > "$release_dir/RELEASE_MANIFEST.md" <<EOF
 - Build timestamp (UTC): $build_time_utc
 - Source repository path: $ROOT_DIR
 - Build command:
-  - \`python3 scripts/public_manifest_tool.py build --root "$ROOT_DIR" --manifest "$ROOT_DIR/release/public-manifest.yaml" --output "$staging_dir"\`
+  - \`$(tm_python_label) scripts/public_manifest_tool.py build --root "$ROOT_DIR" --manifest "$ROOT_DIR/release/public-manifest.yaml" --output "$staging_dir"\`
 - Packaging commands:
   - \`tar -czf task-orchestrator-$release_version.tar.gz -C "$staging_dir" .\`
   - \`zip -qr task-orchestrator-$release_version.zip .\`
@@ -375,7 +376,7 @@ cp "$staging_dir/LICENSE" "$release_dir/LICENSE"
 cp "$staging_dir/THIRD_PARTY_LICENSES.md" "$release_dir/THIRD_PARTY_LICENSES.md"
 
 # Refresh manifest with final delegation state after optional delegation phase.
-python3 - "$release_dir/RELEASE_MANIFEST.md" "$delegation_used" "$docs_management_used" <<'PY'
+tm_python_run - "$release_dir/RELEASE_MANIFEST.md" "$delegation_used" "$docs_management_used" <<'PY'
 from pathlib import Path
 import sys
 
@@ -395,7 +396,7 @@ tar -czf "$release_dir/task-orchestrator-$release_version.tar.gz" -C "$staging_d
   if command -v zip >/dev/null 2>&1; then
     zip -qr "$release_dir/task-orchestrator-$release_version.zip" .
   else
-    python3 - "$release_dir/task-orchestrator-$release_version.zip" <<'PY'
+    tm_python_run - "$release_dir/task-orchestrator-$release_version.zip" <<'PY'
 import os
 import sys
 import zipfile

--- a/scripts/release-public-docs-management.sh
+++ b/scripts/release-public-docs-management.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 version=""
 staging=""
 release_dir=""
+autofixed_changelog_marker=0
+autofixed_readme_marker=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -57,6 +59,37 @@ done
 
 version_token="${version#v}"
 
+ensure_changelog_marker() {
+  local changelog_path="$1"
+  if grep -Eq "${version_token}|${version}" "$changelog_path"; then
+    return
+  fi
+  local tmp_file
+  tmp_file="$(mktemp)"
+  {
+    echo "## [${version_token}] - $(date +%Y-%m-%d)"
+    echo
+    echo "- Release packaging marker for ${version}."
+    echo
+    cat "$changelog_path"
+  } > "$tmp_file"
+  mv "$tmp_file" "$changelog_path"
+  autofixed_changelog_marker=1
+}
+
+ensure_readme_marker() {
+  local readme_path="$1"
+  if grep -Eq "${version_token}|${version}" "$readme_path"; then
+    return
+  fi
+  echo "" >> "$readme_path"
+  echo "<!-- release-version: ${version} -->" >> "$readme_path"
+  autofixed_readme_marker=1
+}
+
+ensure_changelog_marker "$staging/CHANGELOG.md"
+ensure_readme_marker "$release_dir/README.md"
+
 # Basic consistency checks for public docs.
 if ! grep -Eq "${version_token}|${version}" "$staging/CHANGELOG.md"; then
   echo "CHANGELOG.md does not contain release version marker: $version" >&2
@@ -82,6 +115,9 @@ cat > "$release_dir/RELEASE_PUBLIC_DOCS_MANAGEMENT.md" <<EOF
 - Consistency checks:
   - CHANGELOG.md contains release version marker
   - README.md contains release version marker
+- Auto-fixes applied:
+  - CHANGELOG marker inserted: $autofixed_changelog_marker
+  - README marker inserted: $autofixed_readme_marker
 EOF
 
 echo "release-public-docs-management completed for $version"

--- a/scripts/validate-public-manifest.sh
+++ b/scripts/validate-public-manifest.sh
@@ -5,5 +5,6 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$SCRIPT_DIR/lib/python-resolver.sh"
 
-python3 "$SCRIPT_DIR/public_manifest_tool.py" validate "$@"
+tm_python_run "$SCRIPT_DIR/public_manifest_tool.py" validate "$@"


### PR DESCRIPTION
Fixes #62. Auto-inserts missing version markers in staged CHANGELOG and release README before docs consistency checks to prevent computed-version release loops.