### PR TITLE
docs(governance): add merge-method decision matrix to branching strategy

### DIFF
--- a/docs/developer/branching-strategy.md
+++ b/docs/developer/branching-strategy.md
@@ -40,3 +40,19 @@
 
 ### Operational Rule
 - If a direct `main` -> `develop` PR is opened and blocked by merge policy, close it and create a linear sync PR from `develop`.
+
+## Merge Method Decision Matrix (Canonical)
+
+For this repository, the correct merge method depends on the branch pair:
+
+1. feature/* or fix/* -> develop: Squash and merge (recommended).
+2. develop -> main (release PR): Create a merge commit.
+3. hotfix/* -> main: Squash and merge.
+4. main -> develop sync: do not use direct merge or rebase-merge; use the linear cherry-pick sync PR model.
+
+### Rationale
+
+- This policy is defined in this branching strategy and related governance docs.
+- Squash keeps develop clean and supports one-issue-per-commit traceability.
+- Merge commit on develop -> main preserves release boundary/history.
+- Rebase-merge is not a project standard for these flows and can reduce governance traceability in this model.


### PR DESCRIPTION
# Pull Request

## Linked Issue

Closes #78

---

## Type

- [ ] bug
- [ ] refactor
- [ ] feature
- [ ] architecture
- [x] governance
- [ ] infra
- [ ] performance
- [ ] security
- [ ] test
- [x] documentation
- [ ] verification

---

## Summary

Adds a canonical merge-method decision matrix and rationale to the branching strategy so contributors can consistently choose the correct merge strategy by branch pair.

---

## TDD Checklist (Required)

- [ ] New behavior has tests (unit or contract).
- [ ] Bug fixes include a regression test.
- [x] Refactors preserve behavior (tests protect it).
- [x] No skipped tests introduced.
- [ ] CI is green.

If no tests were added, explain why:
Documentation-only governance clarification; no runtime behavior changes.

---

## Architectural Integrity Checklist

- [x] No core-plugin coupling introduced.
- [x] No unintended public API contract changes.
- [x] Provider abstraction remains isolated.
- [x] Middleware ordering preserved (if modified).
- [ ] Breaking change? (If yes, ADR required.)

---

## Issue Hygiene Checklist

- [x] Linked issue exists and matches this PR scope.
- [x] If linked issue contains `blocked-by`, status labels are correct.

---

## Acceptance Criteria Verification

- Criterion 1: Explicit method by branch pair is documented. Added in `docs/developer/branching-strategy.md` under "Merge Method Decision Matrix (Canonical)".
- Criterion 2: Why each method is used is documented. Added rationale bullets directly under the matrix.
- Criterion 3: Guidance aligns with existing governance. Content aligns with current branch model and linear main-to-develop sync runbook.

---

## Risk Notes (Optional)

- Performance impact: none.
- Cost impact: none.
- Latency impact: none.
- Migration required: none.

---

## Additional Notes

This update is intentionally placed in the developer-facing branching strategy doc to keep merge-policy guidance centralized.
